### PR TITLE
fix: add wildcard pattern to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,1 @@
-# https://help.github.com/en/articles/about-code-owners
-
-# TODO: when you fork this repo to make a service you should update this to the team that owns the service:
-@pantheon-systems/pie
+* @pantheon-systems/pie


### PR DESCRIPTION
Adds the required `*` file pattern to the CODEOWNERS entry. Without it, GitHub treats the line as invalid syntax and silently skips it — no ownership is enforced.

> The pattern is followed by one or more GitHub usernames or team names. [...] If any line in your CODEOWNERS file contains invalid syntax, that line will be skipped.
>
> — [About code owners (GitHub Docs)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)