### PR TITLE
Update ownership to canonical team slug

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -12,5 +12,5 @@ metadata:
 spec:
   type: plugin
   lifecycle: beta
-  owner: pie
+  owner: platform-infrastructure-engineering
   system: platform


### PR DESCRIPTION
## Summary
- Update catalog-info.yaml owner from 'pie' to 'platform-infrastructure-engineering'

Part of DELENG-459 to standardize PIE repository ownership metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)