### PR TITLE
chore(DELENG-606): Update CODEOWNERS to use connectivity-api-transformation instead of cat

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pantheon-systems/cat
+* @pantheon-systems/connectivity-api-transformation


### PR DESCRIPTION
Updates CODEOWNERS: `@pantheon-systems/cat` → `@pantheon-systems/connectivity-api-transformation`